### PR TITLE
Bug #90849

### DIFF
--- a/t/01-importer.t
+++ b/t/01-importer.t
@@ -4,22 +4,33 @@ use strict;
 use warnings;
 
 use Catmandu::Importer::MARC;
-use Test::Simple tests => 3;
+use MARC::File::USMARC;
+use Test::Simple tests => 8;
 
-my $importer = Catmandu::Importer::MARC->new( file => 't/camel.usmarc', type => "USMARC" );
-
-my @records;
-
-my $n = $importer->each(
-    sub {
-        push( @records, $_[0] );
-    }
+my $importer = Catmandu::Importer::MARC->new(
+    file => 't/camel.usmarc',
+    type => "USMARC"
 );
+my $records = $importer->to_array();
 
-ok( $records[0]->{'_id'} eq 'fol05731351 ', 'importer: $hashref->{\'_id\'}' );
-ok( $records[0]->{'record'}->[1][-1] eq 'fol05731351 ',
-    'importer: $hashref->{\'record\'}->[1][-1]'
-);
-ok( $records[0]->{'_id'} eq $records[0]->{'record'}->[1][-1],
-    'importer: $hashref->{\'_id\'} eq $hashref->{\'record\'}->[1][-1]'
-);
+ok( scalar keys $records == 10,                           'got all records' );
+ok( $records->[0]->{'_id'} eq 'fol05731351 ',             'got _id' );
+ok( $records->[0]->{'record'}->[1][-1] eq 'fol05731351 ', 'got subfield' );
+ok( $records->[0]->{'_id'} eq $records->[0]->{'record'}->[1][-1],
+    '_id matches record id' );
+
+my $file = MARC::File::USMARC->in('t/camel.usmarc');
+my @marc_objects;
+while ( my $marc = $file->next() ) {
+    push( @marc_objects, $marc );
+}
+$file->close();
+undef $file;
+$importer = Catmandu::Importer::MARC->new( records => \@marc_objects );
+$records = $importer->to_array();
+
+ok( scalar keys $records == 10,                           'got all records' );
+ok( $records->[0]->{'_id'} eq 'fol05731351 ',             'got _id' );
+ok( $records->[0]->{'record'}->[1][-1] eq 'fol05731351 ', 'got subfield' );
+ok( $records->[0]->{'_id'} eq $records->[0]->{'record'}->[1][-1],
+    '_id matches record id' );


### PR DESCRIPTION
Added importer for MARC::Record objects and tests.

```
# import from array of MARC::Record objects
my $importer = Catmandu::Importer::MARC->new(records => \@records);
my $records = $importer->to_array;
```

Added method _record_generator_.
Moved MARC::Record handling to method _decode_marc()_.
