### PR TITLE
Allow the MARC field that the _id comes from to be a subfield

### DIFF
--- a/lib/Catmandu/Importer/MARC.pm
+++ b/lib/Catmandu/Importer/MARC.pm
@@ -157,6 +157,10 @@ sub decode_marc {
     if ($id =~ /^00/ && $record->field($id)) {
         $sysid = $record->field($id)->data();
     }
+    elsif ($id =~ /^(\d{3})([\da-zA-Z])$/) {
+        my $field = $record->field($1);
+        $sysid = $field->subfield($2) if ($field);
+    }
     elsif (defined $id  && $record->field($id)) {
         $sysid = $record->field($id)->subfield("a");
     }
@@ -221,7 +225,8 @@ Create a new MARC importer for $filename or $records. Use STDIN when no filename
 Type describes the sytax of the MARC records. Currently we support: USMARC, MicroLIF
 , XML, ALEPHSEQ or MARC::Record.
 Optionally provide an 'id' option pointing to the identifier field of the MARC record
-(default 001).
+(default 001). If the field isn't a control field, it'll default to the 'a'
+subfield. A subfield can be provided like '999c'.
 
 =head2 count
 

--- a/t/01-importer.t
+++ b/t/01-importer.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Catmandu::Importer::MARC;
 use MARC::File::USMARC;
-use Test::Simple tests => 8;
+use Test::Simple tests => 9;
 
 my $importer = Catmandu::Importer::MARC->new(
     file => 't/camel.usmarc',
@@ -35,3 +35,11 @@ ok( $records->[0]->{'record'}->[1][-1] eq 'fol05731351 ', 'got subfield' );
 ok( $records->[0]->{'_id'} eq $records->[0]->{'record'}->[1][-1],
     '_id matches record id' );
 
+# Test that the ID can be formed like '260c' (not a useful field in real life!)
+$importer = Catmandu::Importer::MARC->new(
+    file => 't/camel.usmarc',
+    type => "USMARC",
+    id   => '260c',
+);
+$records = $importer->to_array();
+ok( $records->[0]->{'_id'} eq '2000.', 'got _id from subfield' );


### PR DESCRIPTION
An _id can be sourced from a control field, or from NNN subfield a. This
allows the id parameter provided to be in the form NNNb, where it will
get the ID from subfield b of field NNN.
