### PR TITLE
bugfix for XML exporter

### DIFF
--- a/lib/Catmandu/Exporter/MARC/XML.pm
+++ b/lib/Catmandu/Exporter/MARC/XML.pm
@@ -63,12 +63,12 @@ has record_format        => (is => 'ro' , default => sub { 'raw'} );
 has skip_empty_subfields => (is => 'ro' , default => sub { 1 });
 has collection           => (is => 'ro' , default => sub { 1 });
 has xml_declaration      => (is => 'ro' , default => sub { 1 });
+has _n                   => (is => 'rw' , default => sub { 0 });
 
 sub add {
     my ($self, $data) = @_;
- 	state $start = 0;
 
- 	if ($start) {
+ 	if ($self->_n == 0) {
     	if ($self->xml_declaration) {
     		$self->fh->print(Catmandu::Util::xml_declaration);
     	}
@@ -77,7 +77,7 @@ sub add {
     		$self->fh->print('<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim">');
     	}
 
-    	$start = 1;
+    	$self->_n(1);
     }
  
 

--- a/t/13-marcxml.t
+++ b/t/13-marcxml.t
@@ -1,0 +1,56 @@
+use strict;
+use warnings;
+
+use Catmandu::Exporter::MARC;
+use XML::LibXML;
+use Test::More;
+
+my $record = {
+  record => [
+            ['001', undef, undef, undef, 'rec002'],
+            ['100', ' ', ' ', 'a', 'Slayer'],
+            ['245', ' ', ' ',
+                'a', 'Reign in Blood' ,
+            ]
+        ]
+};
+
+# XML exporter with default arguments
+
+my $xml = undef;
+my $exporter = Catmandu::Exporter::MARC->new(file => \$xml, type => 'XML');
+$exporter->add($record);
+$exporter->commit;
+my $dom = XML::LibXML->load_xml( string => $xml );
+ok($dom->version() eq '1.0', 'document version');
+ok($dom->encoding() eq 'UTF-8', 'document encoding');
+my $root = $dom->documentElement();
+ok($root->localname eq 'collection', 'root collection');
+ok($root->prefix eq 'marc', 'namespace prefix');
+
+
+# XML exporter with arguments
+
+$xml = undef;
+$exporter = Catmandu::Exporter::MARC->new(file => \$xml, type => 'XML',  collection => 0, xml_declaration => 1);
+$exporter->add($record);
+$exporter->commit;
+$dom = XML::LibXML->load_xml( string => $xml );
+ok($dom->version() eq '1.0', 'document version');
+ok($dom->encoding() eq 'UTF-8', 'document encoding');
+$root = $dom->documentElement();
+ok($root->localname eq 'record', 'root record');
+ok($root->prefix eq 'marc', 'namespace prefix');
+
+# XML exporter with arguments
+
+$xml = undef;
+$exporter = Catmandu::Exporter::MARC->new(file => \$xml, type => 'XML' , collection => 1, xml_declaration => 0);
+$exporter->add($record);
+$exporter->commit;
+$dom = XML::LibXML->load_xml( string => $xml );
+$root = $dom->documentElement();
+ok($root->localname eq 'collection', 'root collection');
+ok($root->prefix eq 'marc', 'namespace prefix');
+
+done_testing;


### PR DESCRIPTION
Bug: MARC XML exporter does not set xml declaration or collection element

```
$ catmandu convert MARC --type RAW to MARC --type XML < ./t/camel.usmarc
<marc:record><marc:leader>00755cam  22002414a 4500</marc:leader>
```

Added bugfix to Catmandu::Exporter::XML and 13-marcxml.t.
