### PR TITLE
check definition of vals with option split

### DIFF
--- a/lib/Catmandu/MARC.pm
+++ b/lib/Catmandu/MARC.pm
@@ -3,7 +3,7 @@ package Catmandu::MARC;
 use Catmandu::Sane;
 use Catmandu::Util;
 use Catmandu::Exporter::MARC::XML;
-use MARC::Spec;
+use MARC::Spec::Parser;
 use List::Util;
 use Memoize;
 use Carp;
@@ -701,7 +701,7 @@ sub _validate_subspec {
 
 sub parse_marc_spec {
     my ( $self, $marc_spec ) = @_;
-    return MARC::Spec->parse( $marc_spec )
+    return MARC::Spec::Parser->new( $marc_spec )->marcspec
 }
 
 sub _get_index_range {

--- a/lib/Catmandu/MARC.pm
+++ b/lib/Catmandu/MARC.pm
@@ -143,7 +143,7 @@ sub marc_map {
         }
     }
 
-    if ($split) {
+    if ($split and defined $vals) {
         $vals = [ $vals ];
     }
     elsif ($append) {

--- a/t/21-marc-spec.t
+++ b/t/21-marc-spec.t
@@ -15,7 +15,7 @@ ok !defined $records->[0]->{my}{no}{field}, q|fix: marc_spec('000', my.no.field)
 
 #field 666 does not exist in camel.usmarc
 #he '$append' fix creates $my->{'references'} hash key with empty array ref as value
-ok !$records->[0]->{'my'}{'references'}, q|fix: marc_map('666', my.references.$append);|;
+ok !$records->[0]->{'my'}{'references'}, q|fix: marc_spec('666', my.references.$append);|;
 
 is_deeply
     $records->[0]->{'my'}{'references2'},
@@ -23,7 +23,7 @@ is_deeply
         'first',
         'IMchF'
     ], 
-    q|fix: add_field(my.references2.$first, 'first'); marc_map('003', my.references2.$append);|;
+    q|fix: add_field(my.references2.$first, 'first'); marc_spec('003', my.references2.$append);|;
 
 is $records->[0]->{my}{title}{all}, 'Cross-platform Perl /Eric F. Johnson.', q|fix: marc_spec('245', my.title.all);|;
 


### PR DESCRIPTION
With $append & split undef values where produced for missing fields.