### PR TITLE
fix subfield codes in Catmandu::Importer::MARC::Line

### DIFF
--- a/lib/Catmandu/Importer/MARC/Line.pm
+++ b/lib/Catmandu/Importer/MARC/Line.pm
@@ -122,12 +122,17 @@ sub generator {
                     # check if field has content
                     if ($sf) {
                         # get subfield codes by pattern
-                        my @sf_codes = $sf =~ m/\s?\$([a-z0-9])\s/g;
+                        # some special characters are allowed as subfiled codes in local defined field
+                        # see https://www.loc.gov/marc/96principl.html#eight 8.4.2.3.
+                        my @sf_codes = $sf =~ m/\s?\$([a-z0-9!"#\$%&'\(\)\*\+'-\.\/:;<=>])\s/g;
 
                         # split string by subfield code pattern
                         my @sf_values
-                            = grep {length $_} split /\s?\$[a-z0-9]\s/, $sf;
-
+                            = grep {length $_}
+                                split
+                                /\s?\$[a-z0-9!"#\$%&'\(\)\*\+'-\.\/:;<=>]\s/,
+                                $sf;
+                           
                         if (scalar @sf_codes != scalar @sf_values) {
                             warn
                                 'different number of subfield codes and values';

--- a/t/Catmandu/Importer/MARC/Line.t
+++ b/t/Catmandu/Importer/MARC/Line.t
@@ -26,6 +26,7 @@ my $record =<<'EOF';
 246 3  $a C4LJ
 362 0  $a 1.2007 -
 856 4  $u http://journal.code4lib.org/
+999    $= foo $< bar $$ baz
 
 EOF
 
@@ -40,7 +41,8 @@ my $expected = {
         [245,   '0', '0', 'a', 'Code4Lib journal', 'b', 'C4LJ'],
         [246,   '3', ' ', 'a', 'C4LJ'],
         [362,   '0', ' ', 'a', '1.2007 -'],
-        [856,   '4', ' ', 'u', 'http://journal.code4lib.org/']
+        [856,   '4', ' ', 'u', 'http://journal.code4lib.org/'],
+        [999,   ' ', ' ', '=', 'foo', '<', 'bar', '$', 'baz']
     ]
 };
 

--- a/t/code4lib.line
+++ b/t/code4lib.line
@@ -7,3 +7,4 @@
 246 3  $a C4LJ
 362 0  $a 1.2007 -
 856 4  $u http://journal.code4lib.org/
+999    $= foo $< bar $$ baz


### PR DESCRIPTION
MARC 21 allows some special (!"#$%&'()*+'-./:;<=>) characters as subfield codes in local defined fields, see https://www.loc.gov/marc/96principl.html#eight 8.4.2.3.. I've fixed Catmandu::Importer::MARC::Line and included these codes.